### PR TITLE
fix(hooks): prevent bus init failure from disabling security hooks

### DIFF
--- a/home/.claude/hooks/common/PreToolUse/block-destructive.sh
+++ b/home/.claude/hooks/common/PreToolUse/block-destructive.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/validate-path.sh"
 hook_register "block-destructive"
 hook_set_context "$INPUT"
-hook_bus_init "$INPUT"
+hook_bus_init "$INPUT" || true  # Bus is non-critical; don't abort security hook
 
 # Only process Bash tool calls
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')

--- a/home/.claude/hooks/common/PreToolUse/exfiltration-check.sh
+++ b/home/.claude/hooks/common/PreToolUse/exfiltration-check.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/validate-path.sh"
 hook_register "exfiltration-check"
 hook_set_context "$INPUT"
-hook_bus_init "$INPUT"
+hook_bus_init "$INPUT" || true  # Bus is non-critical; don't abort security hook
 
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 [[ "$TOOL" != "Bash" ]] && exit 0

--- a/home/.claude/hooks/common/PreToolUse/secret-scanner.sh
+++ b/home/.claude/hooks/common/PreToolUse/secret-scanner.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/validate-path.sh"
 hook_register "secret-scanner"
 hook_set_context "$INPUT"
-hook_bus_init "$INPUT"
+hook_bus_init "$INPUT" || true  # Bus is non-critical; don't abort security hook
 
 TOOL=$(jq -r '.tool_name // ""' <<<"$INPUT")
 FILE_PATH=$(jq -r '.tool_input.file_path // ""' <<<"$INPUT")

--- a/home/.claude/hooks/common/validate-path.sh
+++ b/home/.claude/hooks/common/validate-path.sh
@@ -257,7 +257,10 @@ hook_bus_init() {
   input_hash=$(_short_hash "${tool_input}")
 
   _HOOK_BUS_DIR="/tmp/.claude-hook-bus-${session_id}-${tool_name}-${input_hash}"
-  ensure_dir_exists "$_HOOK_BUS_DIR" || return 1
+  ensure_dir_exists "$_HOOK_BUS_DIR" || {
+    _HOOK_BUS_DIR=""  # Signal bus unavailable so hook_bus_put noops
+    return 1
+  }
 }
 
 # Write a named finding to the bus
@@ -450,8 +453,8 @@ get_project_mode() {
   if [[ -n "$mode_file" ]]; then
     local mode
     mode=$(head -1 "$mode_file" 2>/dev/null | tr -d '[:space:]')
-    # Validate mode is in VALID_MODES
-    if [[ " $VALID_MODES " == *" $mode "* ]]; then
+    # Validate mode is non-empty and in VALID_MODES
+    if [[ -n "$mode" && " $VALID_MODES " == *" $mode "* ]]; then
       echo "$mode"
       return 0
     fi
@@ -485,7 +488,7 @@ set_project_mode() {
   local new_mode="$1"
 
   # Validate
-  if [[ " $VALID_MODES " != *" $new_mode "* ]]; then
+  if [[ -z "$new_mode" || " $VALID_MODES " != *" $new_mode "* ]]; then
     echo "Invalid mode: $new_mode. Valid: $VALID_MODES" >&2
     return 1
   fi


### PR DESCRIPTION
## Summary

- **Bus init failure silently disabled security hooks**: Under `set -euo pipefail`, `hook_bus_init` returning 1 caused `block-destructive.sh`, `secret-scanner.sh`, and `exfiltration-check.sh` to exit immediately — skipping all security checks. Added `|| true` since the bus is a non-critical optimization.
- **Empty string passed mode validation**: `[[ " $VALID_MODES " == *" $mode "* ]]` matches empty `$mode` because the pattern finds adjacent spaces. Added `-n`/`-z` guards in both `get_project_mode` and `set_project_mode`.
- **Hardened `hook_bus_init` itself**: On failure, clears `_HOOK_BUS_DIR=""` so `hook_bus_put` gracefully no-ops instead of potentially writing to a stale path.

## Test plan

- [ ] Simulate bus init failure (e.g., read-only `/tmp`) and verify security hooks still block destructive commands and secrets
- [ ] Write an empty/whitespace-only `project-mode` file and verify `get_project_mode` returns `"default"`
- [ ] Call `set_project_mode ""` and verify it returns 1
- [ ] Run existing BATS test suite: `./test/run-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security hook execution paths; while the change is small and defensive, mistakes could inadvertently alter when destructive/exfiltration/secret checks run or how modes are interpreted.
> 
> **Overview**
> PreToolUse security hooks (`block-destructive`, `exfiltration-check`, `secret-scanner`) no longer abort when `hook_bus_init` fails under `set -e`, treating the bus as best-effort (`hook_bus_init ... || true`).
> 
> `hook_bus_init` now clears `_HOOK_BUS_DIR` on directory-creation failure so downstream `hook_bus_put` effectively no-ops instead of using a stale path.
> 
> Project mode handling is hardened so an empty/whitespace `project-mode` value is rejected: `get_project_mode` falls back to `default`, and `set_project_mode` errors on an empty mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0301fa245dea66b9058f9721617d3c13e2b94a41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->