### PR TITLE
feat(hooks): add test flakiness detection

### DIFF
--- a/home/.claude/hooks/common/PostToolUse/async-test-runner.sh
+++ b/home/.claude/hooks/common/PostToolUse/async-test-runner.sh
@@ -193,6 +193,46 @@ if echo "$TEST_OUTPUT" | grep -qE "^(ok|not ok) [0-9]+" || echo "$TEST_OUTPUT" |
   fi
 fi
 
+# ============================================================================
+# INDIVIDUAL TEST EXTRACTION (Issue #19: Flakiness Detection)
+# ============================================================================
+# Extract individual test names and results for per-test tracking.
+# Currently supports BATS format; other frameworks can be added as needed.
+
+INDIVIDUAL_TESTS="[]"
+PER_TEST_LOG="$HOME/.claude/per-test-results.jsonl"
+
+if [[ "$FRAMEWORK" == "bats" ]]; then
+  # Parse BATS TAP output: "ok 1 test_name" or "not ok 1 test_name"
+  # Extract test file from the output if present
+  TEST_FILE=$(echo "$TEST_OUTPUT" | grep -oE "^# [^ ]+\.bats" | head -1 | sed 's/^# //' || echo "unknown")
+  [[ -z "$TEST_FILE" || "$TEST_FILE" == "unknown" ]] && TEST_FILE="$FILE"
+
+  INDIVIDUAL_TESTS=$(echo "$TEST_OUTPUT" | grep -E "^(ok|not ok) [0-9]+" | while read -r line; do
+    # Parse: "ok 1 test_name" or "not ok 1 test_name # skip reason"
+    if echo "$line" | grep -q "^ok "; then
+      if echo "$line" | grep -q "# skip"; then
+        STATUS="skipped"
+      else
+        STATUS="passed"
+      fi
+    else
+      STATUS="failed"
+    fi
+    # Extract test name (everything after "ok N " or "not ok N ")
+    TEST_NAME=$(echo "$line" | sed -E 's/^(ok|not ok) [0-9]+ //' | sed 's/ # skip.*//' | sed 's/ #.*//')
+    # Output as JSON
+    jq -n --arg name "$TEST_NAME" --arg status "$STATUS" --arg file "$TEST_FILE" \
+      '{name: $name, status: $status, file: $file}'
+  done | jq -s '.')
+
+  # Write individual test results to per-test log
+  if [[ "$INDIVIDUAL_TESTS" != "[]" ]]; then
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo "$INDIVIDUAL_TESTS" | jq -c '.[] | . + {timestamp: "'"$TIMESTAMP"'", project: "'"$PROJECT_ROOT"'"}' >> "$PER_TEST_LOG"
+  fi
+fi
+
 # Extract error message for failed tests (first failure line, max 200 chars)
 ERROR_EXCERPT=""
 if [[ "$RESULT" == "failed" ]]; then
@@ -216,6 +256,9 @@ fi
 # }
 # ============================================================================
 
+# Count individual tests tracked
+INDIVIDUAL_COUNT=$(echo "$INDIVIDUAL_TESTS" | jq 'length')
+
 PAYLOAD=$(jq -n \
   --arg result "$RESULT" \
   --arg framework "$FRAMEWORK" \
@@ -226,6 +269,7 @@ PAYLOAD=$(jq -n \
   --argjson passed "$PASSED" \
   --argjson failed "$FAILED" \
   --argjson skipped "$SKIPPED" \
+  --argjson individual_tests_tracked "$INDIVIDUAL_COUNT" \
   '{
     result: $result,
     framework: $framework,
@@ -236,6 +280,7 @@ PAYLOAD=$(jq -n \
     failed: $failed,
     skipped: $skipped,
     total: ($passed + $failed + $skipped),
+    individual_tests_tracked: $individual_tests_tracked,
     error_excerpt: (if $error_excerpt == "" then null else $error_excerpt end)
   }')
 

--- a/home/.claude/skills/common/weekly-review/CONTRACTS.md
+++ b/home/.claude/skills/common/weekly-review/CONTRACTS.md
@@ -56,6 +56,19 @@ Each line must be valid JSON with these fields:
 - `cue_applied` - Cue guidance was followed (detected via subsequent tool use)
 - `session_end` - Session ended (includes duration and focus metrics)
 
+**Per-test result log (`~/.claude/per-test-results.jsonl`):**
+
+Individual test results for flakiness tracking:
+```json
+{
+  "name": "test_hook_registration",
+  "status": "passed",              // "passed" | "failed" | "skipped"
+  "file": "test/hooks/registration_test.bats",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "project": "/path/to/project"
+}
+```
+
 ### Output
 
 | Destination | Type | Description |
@@ -145,6 +158,24 @@ interface SummaryJSON {
       avg_focus_score: number | null;
       total_hours: number;
     }>;
+  };
+  flaky_tests: {
+    suspects: Array<{                   // Tests with 50-90% pass rate
+      name: string;                     // Test name
+      pass_rate: number;                // 0.5-0.9 (flagged range)
+      runs: number;                     // Total runs this week
+      passed: number;                   // Passed count
+      failed: number;                   // Failed count
+      file: string;                     // Test file path
+    }>;
+    total_suspects: number;             // Total flaky tests found
+    tests_tracked: number;              // Unique tests with results
+    total_test_runs: number;            // Total individual test runs
+    detection_criteria: {
+      min_runs: number;                 // Min runs required (2)
+      pass_rate_range: [number, number]; // [0.5, 0.9]
+      description: string;
+    };
   };
 }
 ```
@@ -462,6 +493,7 @@ OUT_DIR=$(./run_weekly_review.sh)
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.3.0 | 2026-03-31 | Added flaky_tests section for test flakiness detection (Issue #19) |
 | 1.2.0 | 2026-03-31 | Added session_quality metrics (focus_score, archetype) and session_end event type |
 | 1.1.0 | 2026-03-31 | Added cue_applied event type and cue_engagement.conversion_rate metrics |
 | 1.0.0 | 2024-02-25 | Initial contract definition |

--- a/home/.claude/skills/common/weekly-review/scripts/aggregate.sh
+++ b/home/.claude/skills/common/weekly-review/scripts/aggregate.sh
@@ -81,8 +81,9 @@ projects_dir = sys.argv[2]
 out_path = sys.argv[3]
 week_start = sys.argv[4]
 week_end = sys.argv[5]
+per_test_log = Path.home() / ".claude" / "per-test-results.jsonl"
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"  # Added flaky_tests section
 
 def parse_ts(s: str):
     if s.endswith("Z"):
@@ -582,6 +583,82 @@ stable_session_stability = (stable_session_passed / stable_session_total) if sta
 
 session_pattern_counts = Counter(session_classifications.values())
 
+# ============================================================================
+# Flaky Test Detection (Issue #19)
+# ============================================================================
+# Read per-test results and calculate pass rates over the week.
+# Flag tests with 50-90% pass rate as "flaky suspects".
+
+per_test_results = defaultdict(list)  # test_key -> list of (timestamp, status)
+flaky_tests = []
+
+if per_test_log.exists():
+    with open(per_test_log, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+
+            ts = entry.get("timestamp", "")
+            if not ts:
+                continue
+
+            try:
+                t = parse_ts(ts).astimezone(dt.timezone.utc)
+            except Exception:
+                continue
+
+            # Only include results from this week
+            if not (week_start_dt <= t < week_end_dt):
+                continue
+
+            name = entry.get("name", "")
+            status = entry.get("status", "")
+            file_path = entry.get("file", "")
+
+            if name and status:
+                # Use file:name as unique key
+                test_key = f"{file_path}:{name}" if file_path else name
+                per_test_results[test_key].append({
+                    "timestamp": ts,
+                    "status": status,
+                    "file": file_path
+                })
+
+    # Calculate pass rates and identify flaky tests
+    for test_key, runs in per_test_results.items():
+        total_runs = len(runs)
+        if total_runs < 2:  # Need at least 2 runs to detect flakiness
+            continue
+
+        passed_runs = sum(1 for r in runs if r["status"] == "passed")
+        pass_rate = passed_runs / total_runs
+
+        # Flag tests with 50-90% pass rate as flaky suspects
+        if 0.5 <= pass_rate <= 0.9:
+            # Extract file and name from test_key
+            if ":" in test_key:
+                file_path, test_name = test_key.rsplit(":", 1)
+            else:
+                file_path = ""
+                test_name = test_key
+
+            flaky_tests.append({
+                "name": test_name,
+                "pass_rate": round(pass_rate, 2),
+                "runs": total_runs,
+                "passed": passed_runs,
+                "failed": total_runs - passed_runs,
+                "file": file_path
+            })
+
+    # Sort by pass rate (most flaky first = closest to 50%)
+    flaky_tests.sort(key=lambda x: abs(x["pass_rate"] - 0.5))
+
 # Original (raw) metrics for comparison
 total_tests = test_results.get("passed", 0) + test_results.get("failed", 0)
 pass_tests = test_results.get("passed", 0)
@@ -769,7 +846,19 @@ summary = {
             for arch in ["deep_work", "mixed", "exploratory", "fragmented"]
             if any(s.get("archetype") == arch for s in session_durations)
         ]
-    })([s for s in session_durations if s.get("focus_score") is not None])
+    })([s for s in session_durations if s.get("focus_score") is not None]),
+    # Issue #19: Flaky test detection
+    "flaky_tests": {
+        "suspects": flaky_tests[:20],  # Top 20 flaky tests
+        "total_suspects": len(flaky_tests),
+        "tests_tracked": len(per_test_results),
+        "total_test_runs": sum(len(runs) for runs in per_test_results.values()),
+        "detection_criteria": {
+            "min_runs": 2,
+            "pass_rate_range": [0.5, 0.9],
+            "description": "Tests with 50-90% pass rate over rolling 7 days"
+        }
+    }
 }
 
 with open(out_path, "w", encoding="utf-8") as out:


### PR DESCRIPTION
## Summary

- Extends `async-test-runner.sh` to parse individual test names from BATS output
- Writes per-test results to `~/.claude/per-test-results.jsonl` for tracking
- Adds flaky test detection to `aggregate.sh` - calculates rolling 7-day pass rates
- Flags tests with 50-90% pass rate as "flaky suspects" in weekly summary

Closes #19

## Test plan

- [x] Run BATS tests and verify per-test results are logged
- [x] Run weekly aggregation and verify `flaky_tests` section in summary.json
- [ ] Verify tests with consistent pass/fail are not flagged
- [ ] Verify schema version bumped to 1.1.0 in aggregate.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)