### PR TITLE
feat(tradeoff): document significant changes in attachment extractor

### DIFF
--- a/home/.claude/decision-journal/2026-03-31-1605-tradeoff.md
+++ b/home/.claude/decision-journal/2026-03-31-1605-tradeoff.md
@@ -1,0 +1,27 @@
+---
+project: gusto-database_pull
+branch: LDE-722-support-optional-active-storage-attachment-inclusion-in-db-pulls
+source: auto-capture
+files: /Users/meagan.waller/workspace/gusto-database_pull/spec/gusto/database_pull/server/attachment_extractor_spec.rb
+lines_changed: 253
+change_type: unknown
+---
+
+# Tradeoff: 2026-03-31
+
+## Context
+
+Large change detected with tradeoff discussion signals.
+
+## Raw Context (for review)
+
+```
+- Optional props with defaults: `root_entity`, `table_config_registry`, `connection`
+- Constructor now takes a single `params` argument of type `AttachmentExtractorParams`
+- Removed the 6-parameter constructor that triggered the RuboCop `Metrics/ParameterLists` offense
+```
+
+## Notes
+
+_Auto-captured. Review and edit as needed._
+


### PR DESCRIPTION
Add a new tradeoff entry detailing a large change in the attachment extractor's constructor. The update consolidates multiple parameters into a single `params` argument, improving code clarity and addressing RuboCop offenses related to parameter lists. This entry includes context, raw context for review, and notes indicating the auto-captured nature of the information.
