### PR TITLE
refactor(hooks): enhance session duration tracking with JSON support

### DIFF
--- a/home/.claude/hooks/common/PreCompact/pre-compact-snapshot.sh
+++ b/home/.claude/hooks/common/PreCompact/pre-compact-snapshot.sh
@@ -21,7 +21,12 @@ DURATION_MINUTES=0
 ARCHETYPE="unknown"
 SESSION_TRACKER_DIR="$HOME/.claude/.session-trackers"
 if [[ -n "$SESSION_ID" && -f "$SESSION_TRACKER_DIR/$SESSION_ID" ]]; then
-  START_TIME=$(cat "$SESSION_TRACKER_DIR/$SESSION_ID" 2>/dev/null) || START_TIME=0
+  TRACKER_FILE="$SESSION_TRACKER_DIR/$SESSION_ID"
+  if jq -e '.start_time' "$TRACKER_FILE" &>/dev/null; then
+    START_TIME=$(jq -r '.start_time' "$TRACKER_FILE")
+  else
+    START_TIME=$(cat "$TRACKER_FILE" 2>/dev/null) || START_TIME=0
+  fi
   if [[ -n "$START_TIME" && "$START_TIME" -gt 0 ]]; then
     NOW=$(date +%s)
     DURATION_MINUTES=$(( (NOW - START_TIME) / 60 ))

--- a/home/.claude/hooks/common/UserPromptSubmit/session-duration-monitor.sh
+++ b/home/.claude/hooks/common/UserPromptSubmit/session-duration-monitor.sh
@@ -17,8 +17,13 @@ SESSION_TRACKER_DIR="$HOME/.claude/.session-trackers"
 SESSION_FILE="$SESSION_TRACKER_DIR/$SESSION_ID"
 [[ ! -f "$SESSION_FILE" ]] && exit 0
 
-START_TIME=$(cat "$SESSION_FILE" 2>/dev/null) || exit 0
-[[ -z "$START_TIME" ]] && exit 0
+# Same tracker file shape as session-start-tracker (JSON) or legacy plain epoch
+if jq -e '.start_time' "$SESSION_FILE" &>/dev/null; then
+  START_TIME=$(jq -r '.start_time' "$SESSION_FILE")
+else
+  START_TIME=$(cat "$SESSION_FILE" 2>/dev/null) || exit 0
+fi
+[[ -z "$START_TIME" || "$START_TIME" == "null" ]] && exit 0
 
 NOW=$(date +%s)
 DURATION_SECONDS=$((NOW - START_TIME))


### PR DESCRIPTION
Update session duration tracking scripts to support both JSON and legacy plain epoch formats. The changes ensure compatibility with the new session tracker structure by checking for the presence of a 'start_time' field in JSON files, improving robustness and error handling.

