### PR TITLE
Add Bun binary path to Fish configuration

### DIFF
--- a/home/.config/fish/conf.d/00_paths.fish
+++ b/home/.config/fish/conf.d/00_paths.fish
@@ -13,3 +13,7 @@ end
 if test -d "$HOME/.local/bin"
     fish_add_path --universal "$HOME/.local/bin"
 end
+
+if test -d "$HOME/.bun/bin"
+  fish_add_path "/Users/meaganwaller/.bun/bin"
+end


### PR DESCRIPTION
## Related Links

<!-- What links will make reviewing these code changes as straightforward as possible? -->

## What

<!-- Added Bun binary path to Fish configuration. -->

## Why

<!-- This change is necessary to ensure that the Bun binary is accessible in the Fish shell environment. -->

## How

<!-- Added a conditional check to include the Bun binary path if the directory exists. -->

## Designs

<!-- No visual context needed. -->

## Test Steps

<!-- - [ ] Open a terminal with Fish shell -->
<!-- - [ ] Run `echo $PATH` -->
<!-- - [ ] Verify that the Bun binary path is included in the output. -->

## Other Notes

<!-- No additional notes. -->

