### PR TITLE
fix(skills): audit and improve skill frontmatter and config

### DIFF
--- a/home/.claude/skills/common/abstraction-check/SKILL.md
+++ b/home/.claude/skills/common/abstraction-check/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: abstraction-check
 description: This skill should be used when the user asks "should I extract this?", "is this abstraction worth it?", "am I over-engineering?", "should I DRY this up?", or when evaluating whether to create a helper, utility, base class, or shared module. Use for any "extract vs inline" decision.
+argument-hint: code or abstraction to evaluate
 ---
 
 # Abstraction Check

--- a/home/.claude/skills/common/assumption-scan/SKILL.md
+++ b/home/.claude/skills/common/assumption-scan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: assumption-scan
 description: This skill should be used when reviewing a design proposal, RFC, technical plan, or before starting implementation. Use when asking "what could go wrong?", "what are we assuming?", "where is this fragile?", or "what happens if X changes?". Surfaces hidden dependencies and untested beliefs.
+argument-hint: design proposal, RFC, or technical plan to scan
 ---
 
 # Assumption Scan

--- a/home/.claude/skills/common/code-review/SKILL.md
+++ b/home/.claude/skills/common/code-review/SKILL.md
@@ -1,15 +1,13 @@
+---
+name: code-review
+description: This skill should be used when the user asks to "review this code", "check this implementation", "what's wrong with this code", "review my changes", "code review", or when examining code for quality issues.
+argument-hint: file path, PR URL, or description of code to review
+context: fork
+agent: Explore
+allowed-tools: Read, Grep, Glob
+---
+
 # Code Review Skill
-
-This skill should be used when the user asks to "review this code", "check this implementation", "what's wrong with this code", "review my changes", "code review", or when examining code for quality issues.
-
-## Trigger Phrases
-- "review this code"
-- "code review"
-- "check this implementation"
-- "what's wrong here"
-- "review my changes"
-- "is this code okay"
-- "look at this code"
 
 ## Methodology
 

--- a/home/.claude/skills/common/complexity-audit/SKILL.md
+++ b/home/.claude/skills/common/complexity-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: complexity-audit
 description: This skill should be used when asking "is this module too complex?", "why is this hard to change?", "what's causing coupling here?", or before refactoring a tangled system. Use to audit for accidental complexity, circular dependencies, god objects, and layering violations.
+argument-hint: module, directory, or file path to audit
 context: fork
 agent: Explore
 allowed-tools: Read, Grep, Glob

--- a/home/.claude/skills/common/debug-session/SKILL.md
+++ b/home/.claude/skills/common/debug-session/SKILL.md
@@ -1,16 +1,13 @@
+---
+name: debug-session
+description: This skill should be used when the user asks to "help me debug", "why isn't this working", "this is broken", "debug this", "find the bug", or when systematically investigating an issue.
+argument-hint: error message, symptom description, or file path to investigate
+context: fork
+agent: Explore
+allowed-tools: Read, Grep, Glob, Bash
+---
+
 # Debug Session Skill
-
-This skill should be used when the user asks to "help me debug", "why isn't this working", "this is broken", "debug this", "find the bug", or when systematically investigating an issue.
-
-## Trigger Phrases
-- "help me debug"
-- "why isn't this working"
-- "this is broken"
-- "find the bug"
-- "debug this"
-- "not working as expected"
-- "something's wrong with"
-- "investigate this issue"
 
 ## Methodology
 

--- a/home/.claude/skills/common/dependency-evaluator/SKILL.md
+++ b/home/.claude/skills/common/dependency-evaluator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dependency-evaluator
 description: This skill should be used when asking "should we add this library?", "is this dependency safe?", "should we upgrade X?", or when evaluating npm packages, gems, crates, or any third-party code. Assesses maintenance risk, security, and exit strategy.
-disable-model-invocation: true
+argument-hint: package name, version, or dependency to evaluate
 context: fork
 agent: Plan
 ---

--- a/home/.claude/skills/common/design-review/SKILL.md
+++ b/home/.claude/skills/common/design-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: design-review
 description: This skill should be used when reviewing a technical design, RFC, PR description, or architecture proposal. Use when asking "what's wrong with this design?", "what am I missing?", "review my approach", or before implementing significant changes. Surfaces risks, edge cases, and alternatives.
+argument-hint: design doc, RFC, or approach description to review
 context: fork
 agent: Plan
 allowed-tools: Read, Grep, Glob

--- a/home/.claude/skills/common/experiment-design/SKILL.md
+++ b/home/.claude/skills/common/experiment-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment-design
 description: This skill should be used when asking "how do I test this idea?", "will this change help?", "how do I measure success?", or when planning A/B tests, feature rollouts, or performance experiments. Designs falsifiable hypotheses with clear success/failure criteria.
-disable-model-invocation: true
+argument-hint: hypothesis, feature change, or experiment topic
 context: fork
 agent: Plan
 ---

--- a/home/.claude/skills/common/fix-tests/SKILL.md
+++ b/home/.claude/skills/common/fix-tests/SKILL.md
@@ -28,7 +28,7 @@ Fix all failing tests to match current business logic and implementation.
 
 - **Focus on fixing tests** - avoid changing business logic unless absolutely necessary
 - **Preserve test intent** - ensure tests still validate the expected behavior
-- "Analyze complexity of changess" -
+- "Analyze complexity of changes" -
     - if there are 2 or more changed files, or one file with complex logic, then **Do not write tests yourself** - only orchestrate agents!
     - if there is only one changed file, and it's a simple change, then you can write tests yourself.
 
@@ -36,8 +36,8 @@ Fix all failing tests to match current business logic and implementation.
 
 ### Preparation
 
-1. **Read sadd skill if available**
-    - If available, read the sadd skill to understand best practices for managing agents.
+1. **Read project README if available**
+    - If available, read the project README to understand testing conventions and best practices.
 
 2. **Discover test infrastructure**
     - Read @README.md and package.json, Gemfile (or equivalent project config)

--- a/home/.claude/skills/common/friction-deep-dive/SKILL.md
+++ b/home/.claude/skills/common/friction-deep-dive/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: friction-deep-dive
 description: This skill should be used when a friction domain appears repeatedly in weekly reviews, when asking "why do I keep hitting this error?", "how do I get better at X?", or when the friction-escalator surfaces a pattern. Creates deliberate practice plans tied to Dev OS friction taxonomy.
-disable-model-invocation: true
+argument-hint: friction domain or recurring error pattern to analyze
 context: fork
 agent: Explore
 ---

--- a/home/.claude/skills/common/impact-narrative/SKILL.md
+++ b/home/.claude/skills/common/impact-narrative/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: impact-narrative
 description: This skill should be used when writing self-reviews, preparing for promotion discussions, updating stakeholders, or asking "how do I explain this to leadership?", "what's the business impact?", or "how do I write this for my perf review?". Translates technical work into leadership-ready narratives.
+argument-hint: technical work or accomplishment to translate
 disable-model-invocation: true
 ---
 
@@ -228,3 +229,9 @@ Example:
 ### Narrative Version
 
 [Full paragraph version suitable for self-review or stakeholder update]
+
+---
+
+## Related Skills
+
+- **promotion-draft**: Use when assembling a full promotion packet. Start here with impact-narrative to translate individual accomplishments, then use promotion-draft to structure them into a level-appropriate packet with scope evidence and stakeholder support.

--- a/home/.claude/skills/common/mental-model/SKILL.md
+++ b/home/.claude/skills/common/mental-model/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mental-model
 description: This skill should be used before modifying unfamiliar code, when asking "how does this work?", "what would break if I change this?", "help me understand this system", or when onboarding to a new codebase. Builds comprehensive mental model with data flow, invariants, and change impact analysis.
+argument-hint: module, system, or codebase area to understand
 context: fork
 agent: Explore
 allowed-tools: Read, Grep, Glob

--- a/home/.claude/skills/common/mode/SKILL.md
+++ b/home/.claude/skills/common/mode/SKILL.md
@@ -1,16 +1,10 @@
+---
+name: mode
+description: This skill should be used when the user asks to "set mode", "change mode", "switch to exploration", "switch to hardening", "what mode", "current mode", or "/mode". Manages the project phase mode which controls hook and cue strictness.
+argument-hint: mode name (exploration, default, hardening, release)
+---
+
 # Project Phase Mode
-
-This skill should be used when the user asks to "set mode", "change mode", "switch to exploration", "switch to hardening", "what mode", "current mode", or "/mode". Manages the project phase mode which controls hook and cue strictness.
-
-## Trigger Phrases
-- "mode"
-- "set mode"
-- "change mode"
-- "switch to exploration"
-- "switch to hardening"
-- "switch to release"
-- "what mode"
-- "current mode"
 
 ## How to Use
 

--- a/home/.claude/skills/common/promotion-draft/SKILL.md
+++ b/home/.claude/skills/common/promotion-draft/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: promotion-draft
 description: This skill should be used when preparing a promotion packet, writing self-review for leveling, or asking "am I ready for promotion?", "what does senior/staff look like?", or "help me write my promo doc". Generates level-appropriate impact narratives with scope and influence evidence.
+argument-hint: target level, review period, or accomplishments to include
 disable-model-invocation: true
 ---
 
@@ -63,6 +64,12 @@ $ARGUMENTS
 | Company strategy | Influence product/technical direction |
 | Organization building | Grow senior talent, shape culture |
 | Innovation | Novel solutions to hard problems |
+
+---
+
+## Translating Technical Work to Impact
+
+For each accomplishment, use the **impact-narrative** skill to translate technical work into business language. It provides frameworks for quantifying impact, framing for different audiences, and the STAR-L narrative structure. This skill focuses on assembling those translated accomplishments into a level-appropriate promotion packet.
 
 ---
 

--- a/home/.claude/skills/common/refactor-safely/SKILL.md
+++ b/home/.claude/skills/common/refactor-safely/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refactor-safely
 description: This skill should be used when planning a refactor, asking "how do I safely change this?", "what's the safest way to restructure?", or before touching legacy code, renaming abstractions, or extracting modules. Creates staged refactor plans with validation checkpoints and rollback strategies.
-disable-model-invocation: true
+argument-hint: code, module, or area to refactor
 context: fork
 agent: Plan
 ---

--- a/home/.claude/skills/common/risk-audit/SKILL.md
+++ b/home/.claude/skills/common/risk-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: risk-audit
 description: This skill should be used before deploying changes, when asking "what could go wrong?", "is this safe to ship?", "what are the failure modes?", or when reviewing PRs for production readiness. Audits for hidden risks, silent failures, and edge cases.
-disable-model-invocation: true
+argument-hint: change, PR, or deployment to audit
 context: fork
 agent: Explore
 ---

--- a/home/.claude/skills/common/root-cause/SKILL.md
+++ b/home/.claude/skills/common/root-cause/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: root-cause
 description: This skill should be used after a bug, incident, or unexpected behavior, when asking "why did this happen?", "what's the root cause?", "why did this break?", or during post-mortems. Performs structured 5-Whys analysis with timeline, contributing factors, and preventative recommendations.
+argument-hint: bug, incident, or unexpected behavior to analyze
 context: fork
 agent: Explore
 allowed-tools: Read, Grep, Glob

--- a/home/.claude/skills/common/standup/SKILL.md
+++ b/home/.claude/skills/common/standup/SKILL.md
@@ -1,15 +1,9 @@
+---
+name: standup
+description: This skill should be used when the user asks for "standup", "daily standup", "what did I do yesterday", "what should I work on today", "standup summary", or at the start of a workday.
+---
+
 # Standup Skill
-
-This skill should be used when the user asks for "standup", "daily standup", "what did I do yesterday", "what should I work on today", "standup summary", or at the start of a workday.
-
-## Trigger Phrases
-- "standup"
-- "daily standup"
-- "what did I do yesterday"
-- "what did I accomplish"
-- "standup summary"
-- "morning standup"
-- "start of day"
 
 ## How to Use
 

--- a/home/.claude/skills/common/template-context/SKILL.md
+++ b/home/.claude/skills/common/template-context/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: template-context
 description: This skill should be used when the user asks about "testing Rails generators", "ERB coverage", "template branch coverage", "SimpleCov showing 0%", "untestable template logic", or when building Rails generators with conditional ERB templates. Guides extraction of template conditionals into testable POROs.
+argument-hint: template file or generator with conditional logic
 ---
 
 # TemplateContext Pattern

--- a/home/.claude/skills/common/tradeoff-memo/SKILL.md
+++ b/home/.claude/skills/common/tradeoff-memo/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tradeoff-memo
 description: This skill should be used when documenting architectural decisions, when the large-diff-escalator requests tradeoff documentation, when writing ADRs, or when asking "why did we choose this?", "document this decision", or "what were the tradeoffs?". Produces staff-level decision memos with options analysis and principles.
+argument-hint: decision or architectural choice to document
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary

- **Add YAML frontmatter** to 4 skills (code-review, debug-session, mode, standup) that were missing `name`/`description` fields, breaking skill triggering
- **Fix `disable-model-invocation` + `agent` conflict** in 5 skills — these had contradictory config where the agent would never spawn
- **Add `argument-hint`** to 16 skills that accept `$ARGUMENTS` but lacked usage hints
- **Add `context: fork` + `agent: Explore`** to code-review and debug-session so they can actually read the code they're reviewing/debugging
- **Fix typos** in fix-tests (misspelling + nonexistent skill reference)
- **Cross-reference** impact-narrative and promotion-draft into a clear workflow

## Test plan

- [ ] Verify skills still trigger correctly (e.g., `/code-review`, `/debug-session`, `/mode`)
- [ ] Verify forked skills (code-review, debug-session) can explore codebases when invoked
- [ ] Run `./bin/link-dotfiles` and confirm symlinks are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)