### PR TITLE
Remove Ruby compile setting from mise configuration

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -2,8 +2,6 @@
 experimental = true
 auto_install = true
 
-[settings.ruby]
-compile = true
 # Lockfiles (mise.lock, mise.<profile>.lock next to this config): run `mise lock`
 # from the linked ~/.config/mise directory after changing [tools], or `mise run mise:lock`
 # from the dotfiles repo. CI can use `mise install --locked` to avoid GitHub API


### PR DESCRIPTION
Eliminate the Ruby compile setting from the mise configuration to streamline the setup process. This change simplifies the configuration by removing unnecessary settings.

