### PR TITLE
Integrate Atuin environment in bash, zsh, and fish configurations

### DIFF
--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -6,3 +6,5 @@ fi
 # macOS specific setup (only if files exist)
 [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
 [ -f "/opt/homebrew/bin/brew" ] && eval "$(/opt/homebrew/bin/brew shellenv)"
+
+. "$HOME/.atuin/bin/env"

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -136,3 +136,8 @@ fi
 #######################################
 
 tmux source-file ~/.tmux.conf >/dev/null 2>&1 || true
+
+. "$HOME/.atuin/bin/env"
+
+[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh
+eval "$(atuin init bash)"

--- a/home/.config/atuin/config.toml
+++ b/home/.config/atuin/config.toml
@@ -4,7 +4,15 @@
 ## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command.
 ## Press tab to return to the shell and edit.
 enter_accept = true
+search_mode = "daemon-fuzzy"
 
 [sync]
 # Enable sync v2 by default
 records = true
+
+[ai]
+enabled = true
+
+[daemon]
+enabled = true
+autostart = true

--- a/home/.config/fish/conf.d/atuin.env.fish
+++ b/home/.config/fish/conf.d/atuin.env.fish
@@ -1,0 +1,2 @@
+
+source "$HOME/.atuin/bin/env.fish"

--- a/home/.gitignore_global
+++ b/home/.gitignore_global
@@ -8,3 +8,5 @@ log/
 *.pem
 .cursor/plans
 .claude/settings.local.json
+
+.vim/undo

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -85,3 +85,7 @@ if [[ -o interactive ]]; then
     exec tmux new-session -A -s main
   fi
 fi
+
+. "$HOME/.atuin/bin/env"
+
+eval "$(atuin init zsh)"


### PR DESCRIPTION
## Related Links

<!-- What links will make reviewing these code changes as straightforward as possible? -->

## What

Added Atuin environment integration for bash, zsh, and fish shell configurations.

## Why

This integration enhances shell functionality by enabling command history synchronization and AI features.

## How

Implemented sourcing of Atuin environment files in respective shell configuration files.

## Designs

<!-- What visual context do reviewers need? -->

## Test Steps

- [ ] Open a terminal with bash, zsh, and fish
- [ ] Verify that Atuin initializes correctly
- [ ] Test command history synchronization across sessions

## Other Notes

<!-- What, if anything, hasn't been addressed in these code changes but should be in future changes? -->

