### PR TITLE
fix(install): validate profile name before proceeding

### DIFF
--- a/bin/link-dotfiles
+++ b/bin/link-dotfiles
@@ -9,6 +9,8 @@ DOTFILES_DRY_RUN="${DOTFILES_DRY_RUN:-0}"
 ONLY_MISE=0
 
 # shellcheck source=/dev/null
+source "$ROOT/lib/common.sh"
+# shellcheck source=/dev/null
 source "$ROOT/bin/make-symlink"
 
 log() {
@@ -29,6 +31,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 export DOTFILES_PROFILE="$PROFILE" DOTFILES_DRY_RUN
+
+validate_profile "$PROFILE"
 
 run() {
   if [[ "$DOTFILES_DRY_RUN" -eq 1 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ export DOTFILES_ROOT="$ROOT"
 source "$ROOT/lib/common.sh"
 
 parse_args "$@"
+validate_profile "$DOTFILES_PROFILE"
 
 log "Profile: $DOTFILES_PROFILE"
 export MISE_ENV="${DOTFILES_PROFILE:-work}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -70,6 +70,25 @@ parse_args() {
   export DOTFILES_PROFILE DOTFILES_DRY_RUN
 }
 
+VALID_PROFILES=(work personal server container)
+
+validate_profile() {
+  local profile="${1:-}"
+  if [[ -z "$profile" ]]; then
+    die "No profile specified. Valid profiles: ${VALID_PROFILES[*]}"
+  fi
+  local valid=0
+  for p in "${VALID_PROFILES[@]}"; do
+    if [[ "$p" == "$profile" ]]; then
+      valid=1
+      break
+    fi
+  done
+  if [[ "$valid" -eq 0 ]]; then
+    die "Unknown profile: '$profile'. Valid profiles: ${VALID_PROFILES[*]}"
+  fi
+}
+
 ensure_mise() {
   if ! command -v mise >/dev/null 2>&1; then
     die "mise not installed. Install it first: https://mise.jdx.dev/"

--- a/test/profile-validation.bats
+++ b/test/profile-validation.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# Tests for profile validation in install and link-dotfiles scripts
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export DOTFILES_ROOT="$BATS_TEST_DIRNAME/.."
+  source "$DOTFILES_ROOT/lib/common.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+# ============================================================================
+# validate_profile
+# ============================================================================
+
+@test "validate_profile accepts 'work'" {
+  run validate_profile "work"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "validate_profile accepts 'personal'" {
+  run validate_profile "personal"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "validate_profile accepts 'server'" {
+  run validate_profile "server"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "validate_profile accepts 'container'" {
+  run validate_profile "container"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "validate_profile rejects unknown profile" {
+  run validate_profile "typo"
+  [[ "$status" -ne 0 ]]
+  [[ "$output" =~ "Unknown profile" ]]
+  [[ "$output" =~ "typo" ]]
+}
+
+@test "validate_profile rejects empty profile" {
+  run validate_profile ""
+  [[ "$status" -ne 0 ]]
+  [[ "$output" =~ "No profile specified" ]]
+}
+
+@test "validate_profile lists valid profiles in error message" {
+  run validate_profile "bogus"
+  [[ "$output" =~ "work" ]]
+  [[ "$output" =~ "personal" ]]
+  [[ "$output" =~ "server" ]]
+  [[ "$output" =~ "container" ]]
+}
+
+# ============================================================================
+# link-dotfiles integration
+# ============================================================================
+
+@test "link-dotfiles rejects invalid profile with --dry-run" {
+  run "$DOTFILES_ROOT/bin/link-dotfiles" --profile invalid --dry-run
+  [[ "$status" -ne 0 ]]
+  [[ "$output" =~ "Unknown profile" ]]
+}
+
+@test "link-dotfiles accepts valid profile with --dry-run" {
+  run "$DOTFILES_ROOT/bin/link-dotfiles" --profile work --dry-run
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Would link" ]]
+}


### PR DESCRIPTION
## Summary

- Adds `validate_profile()` to `lib/common.sh` that checks the profile against the known set (`work`, `personal`, `server`, `container`)
- Calls validation early in both `install.sh` and `bin/link-dotfiles` so invalid profiles fail fast with a clear error
- Adds 9 BATS tests covering valid profiles, invalid profiles, empty input, and link-dotfiles integration

## Before

```
$ ./install.sh --profile typo
# silently proceeds, skips profile-specific configs
```

## After

```
$ ./install.sh --profile typo
[x] Unknown profile: 'typo'. Valid profiles: work personal server container
```

## Test plan

- [x] `bats test/profile-validation.bats` — 9 tests pass
- [x] `bats test/hooks/*.bats` — 210 existing tests still pass
- [x] `shellcheck lib/common.sh bin/link-dotfiles install.sh` — clean
- [ ] CI workflow passes

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)