### PR TITLE
fix(cli): resolve dotfiles root dynamically

### DIFF
--- a/home/.local/bin/dotfiles
+++ b/home/.local/bin/dotfiles
@@ -4,7 +4,12 @@ set -euo pipefail
 # Dotfiles CLI
 # Usage: dotfiles <command> [options]
 
-DOTFILES_ROOT="${DOTFILES_ROOT:-$HOME/github/meaganewaller/.dotfiles}"
+# Resolve DOTFILES_ROOT by following this script's symlink back to the repo.
+# The script lives at <repo>/home/.local/bin/dotfiles, so the repo root is 4 levels up.
+if [[ -z "${DOTFILES_ROOT:-}" ]]; then
+  script_path="$(realpath "${BASH_SOURCE[0]}")"
+  DOTFILES_ROOT="$(cd "$(dirname "$script_path")/../../.." && pwd)"
+fi
 PROFILE="${DOTFILES_PROFILE:-work}"
 
 # Colors


### PR DESCRIPTION
## Summary

- Replaces hardcoded `$HOME/github/meaganewaller/.dotfiles` path in the `dotfiles` CLI with dynamic resolution via `realpath` on the script's symlink
- `DOTFILES_ROOT` env var override still works as before

## Before

```bash
DOTFILES_ROOT="${DOTFILES_ROOT:-$HOME/github/meaganewaller/.dotfiles}"
# Breaks if repo is cloned elsewhere or username differs
```

## After

```bash
# Follows symlink: ~/.local/bin/dotfiles → <repo>/home/.local/bin/dotfiles
# Derives repo root as 3 directories up from the script's real location
script_path="$(realpath "${BASH_SOURCE[0]}")"
DOTFILES_ROOT="$(cd "$(dirname "$script_path")/../../.." && pwd)"
```

## Test plan

- [x] `dotfiles help` works from symlink (`~/.local/bin/dotfiles`)
- [x] `dotfiles help` works when invoked directly from repo
- [x] `DOTFILES_ROOT=/custom/path dotfiles help` still respects the override
- [x] `shellcheck` passes clean
- [ ] CI passes

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)