### PR TITLE
fix(profiles): add missing stubs for server and container profiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,7 @@ The repository supports multiple profiles to handle different machine contexts:
 │ Full macOS  │ Full macOS  │ CLI only    │ Minimal     │         │
 │ Work git ID │ Personal ID │ No GUI apps │ DevContainer│         │
 │ Work SSH    │ Personal SSH│ SSH only    │ Shell+Git   │         │
-│ Gusto tools │ Personal    │             │             │         │
+│ Gusto tools │ Personal    │ Common only │ Common only │         │
 └─────────────┴─────────────┴─────────────┴─────────────┴─────────┘
 ```
 

--- a/home/.claude/settings/container/basics.jsonc
+++ b/home/.claude/settings/container/basics.jsonc
@@ -1,0 +1,4 @@
+{
+    // Container profile — minimal devcontainer setup.
+    "$schema": "https://json.schemastore.org/claude-code-settings.json"
+}

--- a/home/.claude/settings/server/basics.jsonc
+++ b/home/.claude/settings/server/basics.jsonc
@@ -1,0 +1,4 @@
+{
+    // Server profile — CLI-only, no GUI or status line customization.
+    "$schema": "https://json.schemastore.org/claude-code-settings.json"
+}

--- a/home/.config/mise/config.container.toml
+++ b/home/.config/mise/config.container.toml
@@ -1,0 +1,2 @@
+# Container profile — layered when MISE_ENV=container (via miserc.toml at link time).
+# Minimal devcontainer setup. Add container-specific tools here as needed.

--- a/home/.config/mise/config.server.toml
+++ b/home/.config/mise/config.server.toml
@@ -1,0 +1,2 @@
+# Server profile — layered when MISE_ENV=server (via miserc.toml at link time).
+# CLI-only machines: no GUI tools. Add server-specific CLIs here as needed.


### PR DESCRIPTION
## Summary

- Adds `config.server.toml` and `config.container.toml` mise layer stubs so `MISE_ENV` resolves explicitly instead of silently falling back
- Adds `settings/server/basics.jsonc` and `settings/container/basics.jsonc` so Claude settings merge has a profile directory to read
- Updates `ARCHITECTURE.md` profile table to clarify server/container use "Common only" configs

These profiles were valid in `VALID_PROFILES` and had `miserc.*.toml` files, but missing config layers caused silent no-ops in mise and the Claude settings merge.

Closes #53

## Test plan

- [ ] `./home/.claude/install.sh --profile server --dry-run` completes without errors
- [ ] `./home/.claude/install.sh --profile container --dry-run` completes without errors
- [ ] `MISE_ENV=server mise config` shows `config.server.toml` in resolved files

🤖 Generated with [Claude Code](https://claude.com/claude-code)