### PR TITLE
fix(bootstrap): improve error context in bootstrap and install scripts

### DIFF
--- a/bootstrap/remote-bootstrap.sh
+++ b/bootstrap/remote-bootstrap.sh
@@ -73,19 +73,34 @@ op_auth_if_needed() {
 }
 
 read_op_field() {
-  op item get "$1" --fields "$2" 2>/dev/null || true
+  local item="$1" field="$2"
+  local value
+  if ! value="$(op item get "$item" --fields "$field" 2>&1)"; then
+    log "WARNING: 'op item get $item --fields $field' failed: $value"
+    echo ""
+    return 1
+  fi
+  if [[ -z "$value" ]]; then
+    log "WARNING: 1Password field '$field' in item '$item' is empty"
+    return 1
+  fi
+  echo "$value"
 }
 
 generate_gitconfigs() {
   log "Generating git configs from 1Password"
 
-  WORK_EMAIL="$(read_op_field "$OP_WORK_ITEM" email)"
-  WORK_KEY="$(read_op_field "$OP_WORK_ITEM" signingkey)"
-  PERSONAL_EMAIL="$(read_op_field "$OP_PERSONAL_ITEM" email)"
-  PERSONAL_KEY="$(read_op_field "$OP_PERSONAL_ITEM" signingkey)"
+  local missing=()
+  WORK_EMAIL="$(read_op_field "$OP_WORK_ITEM" email)" || missing+=("$OP_WORK_ITEM/email")
+  WORK_KEY="$(read_op_field "$OP_WORK_ITEM" signingkey)" || missing+=("$OP_WORK_ITEM/signingkey")
+  PERSONAL_EMAIL="$(read_op_field "$OP_PERSONAL_ITEM" email)" || missing+=("$OP_PERSONAL_ITEM/email")
+  PERSONAL_KEY="$(read_op_field "$OP_PERSONAL_ITEM" signingkey)" || missing+=("$OP_PERSONAL_ITEM/signingkey")
 
-  [[ -n "$WORK_EMAIL" && -n "$WORK_KEY" ]] || die "Missing fields in $OP_WORK_ITEM"
-  [[ -n "$PERSONAL_EMAIL" && -n "$PERSONAL_KEY" ]] || die "Missing fields in $OP_PERSONAL_ITEM"
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "Missing 1Password fields: ${missing[*]}
+    Ensure 'op' is signed in (op signin) and items exist with 'email' and 'signingkey' fields.
+    Check with: op item get \"<item>\" --fields email,signingkey"
+  fi
 
   cat > "$HOME/.gitconfig.work" <<EOF
 [user]

--- a/home/.claude/install.sh
+++ b/home/.claude/install.sh
@@ -115,7 +115,12 @@ merge_config() {
   # 3. Parse JSONC using single Node process
   # ---------------------------------------------
 
-  parsed_json=$(npx -y -p json5 node -e "
+  if ! command -v npx &>/dev/null; then
+    log "npx not found. Install Node.js via mise (mise install node) or brew (brew install node)."
+    return 1
+  fi
+
+  if ! parsed_json=$(npx -y -p json5 node -e "
     const fs = require('fs');
     const JSON5 = require('json5');
 
@@ -126,7 +131,12 @@ merge_config() {
         console.log('{}');
       }
     });
-  " "${settings_files[@]}")
+  " "${settings_files[@]}" 2>&1); then
+    log "JSONC parsing failed. This usually means npm cannot fetch the json5 package."
+    log "Check your network connection, or install json5 globally: npm install -g json5"
+    log "npx output: $parsed_json"
+    return 1
+  fi
 
   # ---------------------------------------------
   # 4. Merge with jq (preserving internal state)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -91,7 +91,9 @@ validate_profile() {
 
 ensure_mise() {
   if ! command -v mise >/dev/null 2>&1; then
-    die "mise not installed. Install it first: https://mise.jdx.dev/"
+    die "mise not found on PATH. Install it: curl https://mise.jdx.dev/install.sh | sh
+    Then add to your shell: eval \"\$(mise activate bash)\"
+    Docs: https://mise.jdx.dev/getting-started.html"
   fi
 }
 


### PR DESCRIPTION
## Summary

- **`ensure_mise()`**: includes install command (`curl ... | sh`), shell activation step, and docs link instead of a bare URL
- **`read_op_field()`**: captures and surfaces `op` CLI errors instead of swallowing them with `|| true`; reports exactly which item/field failed
- **`generate_gitconfigs()`**: collects all missing fields before dying, so users see every problem at once with recovery steps
- **`merge_config()`**: checks for `npx` before attempting JSONC parse; captures stderr and shows actionable recovery on failure

Closes #59

## Test plan

- [ ] `shellcheck` passes on all three modified files
- [ ] `./install.sh --dry-run --profile work` still completes successfully
- [ ] With `op` signed out, `bootstrap/remote-bootstrap.sh` shows which fields failed (not a silent empty string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)