### PR TITLE
docs(adr): add core ADRs for profile system, symlink strategy, and settings merge

### DIFF
--- a/docs/architecture/0002-profile-system.md
+++ b/docs/architecture/0002-profile-system.md
@@ -1,0 +1,65 @@
+---
+status: accepted
+date: 2026-04-19
+deciders: [meaganewaller]
+---
+
+# 2. Environment-variable-based profile system
+
+## Status
+
+Accepted
+
+## Context
+
+This dotfiles repository manages configuration across multiple machine contexts: a work macOS laptop, a personal macOS machine, headless servers, and devcontainers. Each context needs a different subset of tools, git identity, SSH keys, and shell behaviour.
+
+Without a profile system, the options are:
+
+- **Single config for everything** — leads to work tools on personal machines and vice versa, wrong git identity on commits, and unnecessary packages on servers.
+- **Separate branches per machine** — diverges quickly and merges become painful.
+- **Separate repos** — duplicates shared config (shell, editor, git aliases).
+
+We need a way to share common configuration while varying specific layers per context.
+
+## Decision
+
+1. **Four named profiles** — `work`, `personal`, `server`, `container` — cover the current machine contexts. Profiles are validated at install time against `VALID_PROFILES` in `lib/common.sh`.
+
+2. **`DOTFILES_PROFILE` environment variable** is the primary selection mechanism, defaulting to `work`. It can also be passed as `--profile <name>` to `install.sh`, `bin/link-dotfiles`, and the Claude Code installer.
+
+3. **Layered configuration** — each subsystem uses a common base plus profile-specific overrides:
+   - **Brewfiles**: profile selects which layers to install (`base gui dev infra` for work, `base gui creative dev infra` for personal, none for server/container).
+   - **mise**: `MISE_ENV` is set from `DOTFILES_PROFILE`; `config.<profile>.toml` layers on `config.toml`.
+   - **Git identity**: `.gitconfig` uses `includeIf` to load `.gitconfig.work` or `.gitconfig.personal`.
+   - **SSH**: `.ssh/config` includes `.ssh/config.<profile>`.
+   - **Claude Code**: settings merged from `settings/common/` + `settings/<profile>/`.
+   - **Symlinks**: `bin/link-dotfiles` conditionally links profile-specific files (e.g., hammerspoon, karabiner only on macOS profiles).
+
+4. **Server and container profiles** intentionally use common-only configs — they are minimal environments with no GUI or profile-specific tooling. Stub files exist so the profile system resolves explicitly rather than silently falling back.
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| **Git branches per machine** | Shared config diverges; merges are error-prone and manual |
+| **Symlink farm tool (GNU Stow)** | Adds a dependency; doesn't solve the layering/override problem |
+| **Hostname-based detection** | Brittle (hostnames change), doesn't generalise to containers or new machines |
+| **Interactive installer prompts** | Slower, not idempotent, harder to automate in CI |
+
+## Consequences
+
+**Positive**
+
+- Same repo, same branch for all machines — `git pull` gets everything
+- Adding a new profile is additive: create stub files, add to `VALID_PROFILES`, done
+- `install.sh` is idempotent and non-interactive (good for CI and fresh machine bootstrap)
+
+**Negative**
+
+- Profile must be set correctly; wrong profile = wrong git identity on commits (mitigated by `validate_profile` and defaulting to `work`)
+- Server/container profiles carry common config that may include tools they don't need (acceptable tradeoff for simplicity)
+
+**Neutral**
+
+- Adding a fifth profile (e.g., `ci`) requires touching several files but the pattern is well-established

--- a/docs/architecture/0003-symlink-strategy.md
+++ b/docs/architecture/0003-symlink-strategy.md
@@ -1,0 +1,66 @@
+---
+status: accepted
+date: 2026-04-19
+deciders: [meaganewaller]
+---
+
+# 3. Symlink strategy for dotfiles deployment
+
+## Status
+
+Accepted
+
+## Context
+
+Dotfiles need to get from the repository (`home/`) into `$HOME` where tools expect them. The deployment mechanism must be:
+
+- **Idempotent** — safe to run repeatedly without side effects
+- **Transparent** — edits in `$HOME` are immediately visible in the repo (and vice versa)
+- **Reversible** — easy to undo without data loss
+- **Profile-aware** — some files should only appear for certain profiles (see [ADR 0002](0002-profile-system.md))
+
+## Decision
+
+1. **Symlinks from `$HOME` into the repo** — `~/.zshrc` -> `.dotfiles/home/.zshrc`. Edits in either location are the same file.
+
+2. **Directory-level symlinks by default** — `run ".config/nvim"` symlinks the entire directory, not individual files. This avoids maintaining a manifest of every file within a config directory.
+
+3. **Exceptions for directories that don't tolerate symlinks**:
+   - **Fish shell** (`~/.config/fish/`) — Fish writes runtime files (e.g., `fish_variables`) into its config directory. A directory symlink would put these generated files into the repo. Instead, `run_dir_contents` symlinks individual files within the directory.
+
+4. **`make-symlink` helper** provides idempotent symlink creation:
+   - Creates parent directories as needed
+   - Backs up existing files to `*.backup` before replacing
+   - Skips if the symlink already points to the correct target
+   - Never deletes — only creates or backs up
+
+5. **Conditional linking** — `bin/link-dotfiles` uses profile checks to link GUI-specific files (hammerspoon, karabiner, sketchybar) only for work/personal profiles.
+
+6. **Files never symlinked**: `README.md` files (repo documentation only), `*.example` files (templates).
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| **Copy files** | Edits in `$HOME` aren't reflected in the repo; requires a sync step; easy to lose changes |
+| **GNU Stow** | Adds a system dependency; its directory-tree mirroring is less flexible than explicit `run` calls for profile-conditional linking |
+| **Git bare repo with `$HOME` as worktree** | Every `git status` in `$HOME` shows untracked files; `.gitignore` becomes unmanageable; no profile layering |
+| **Ansible/Chef/Nix** | Heavyweight for personal dotfiles; steep learning curve for contributors; overkill for the problem |
+
+## Consequences
+
+**Positive**
+
+- Zero-copy: changes are instantly visible in both the repo and the live config
+- Backup-on-replace means no data loss during re-linking
+- Simple mental model: `home/` mirrors `$HOME`
+
+**Negative**
+
+- Directory symlinks mean the entire directory is either linked or not — you can't exclude individual files within a directory (mitigated by the `run_dir_contents` exception pattern)
+- Tools that write into their config directory (like Fish) need special handling
+- Moving the repo breaks all symlinks (mitigated by using absolute paths)
+
+**Neutral**
+
+- `ls -la` in `$HOME` shows symlinks, which is visually noisy but also makes it obvious which files are managed

--- a/docs/architecture/0004-claude-settings-merge.md
+++ b/docs/architecture/0004-claude-settings-merge.md
@@ -1,0 +1,64 @@
+---
+status: accepted
+date: 2026-04-19
+deciders: [meaganewaller]
+---
+
+# 4. JSONC merge strategy for Claude Code settings
+
+## Status
+
+Accepted
+
+## Context
+
+Claude Code reads a single `~/.claude/settings.json` file. This dotfiles repository needs to:
+
+- **Share common settings** (hooks, permissions, base preferences) across all profiles
+- **Override per profile** (work adds Gusto env vars and a different status line; personal has its own status line)
+- **Preserve internal state** that Claude Code writes to `settings.json` at runtime (e.g., `numStartups`, `userID`, `projects`)
+- **Use JSONC** (JSON with comments) in source files for readability, even though Claude Code reads plain JSON
+
+A single checked-in `settings.json` would force choosing one profile's config, and Claude Code's runtime writes would create constant merge conflicts.
+
+## Decision
+
+1. **Source files are JSONC** — stored in `home/.claude/settings/common/` and `home/.claude/settings/<profile>/`, split by concern (e.g., `base.jsonc`, `hooks.jsonc`, `permissions/*.jsonc`).
+
+2. **Merge at install time** — `home/.claude/install.sh` runs `merge_config()` which:
+   - Discovers all `.jsonc`/`.json` files under `common/` then `<profile>/` using `fd`, sorted deterministically
+   - Parses JSONC to JSON using `npx -y -p json5 node` (single Node process for all files)
+   - Deep-merges with `jq`, profile values overriding common values
+   - **Permissions are union-merged**: `allow`, `deny`, and `additionalDirectories` arrays are concatenated and deduplicated across all layers
+   - All other keys use last-writer-wins (profile overrides common)
+
+3. **Internal state preservation** — before merging, the existing `settings.json` is read and Claude Code's internal fields (`numStartups`, `userID`, `projects`, etc.) are extracted. These are merged back in after the dotfiles layers, so they survive re-linking.
+
+4. **Profile directories may be empty stubs** — server and container profiles have minimal `basics.jsonc` files so the merge has a directory to scan without errors.
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| **Single `settings.json` per profile** | Duplicates shared config (hooks, permissions); changes must be applied to every copy |
+| **JSON (no comments)** | Settings files benefit from inline documentation explaining why a permission or hook exists |
+| **Template rendering (ERB, envsubst)** | Adds complexity; JSONC + jq merge is sufficient for key-value overrides |
+| **Claude Code's native config** | Claude Code doesn't support config layering or profile merging natively |
+
+## Consequences
+
+**Positive**
+
+- Single source of truth for each setting — common settings are defined once
+- Profile overrides are explicit and auditable (separate files, not environment variable interpolation)
+- Internal state survives re-linking without manual intervention
+
+**Negative**
+
+- **Depends on Node.js and jq** — both must be available at install time (checked with actionable error messages per [ADR context])
+- **npx network dependency** — first run fetches `json5` package; fails without network access (mitigated by checking for npx and providing fallback guidance)
+- Merge order matters — profile files override common files, but within a layer, files are sorted alphabetically
+
+**Neutral**
+
+- Adding a new settings concern means creating a new `.jsonc` file in the appropriate directory; no wiring needed beyond the file existing

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,6 +19,9 @@ This directory records **repository-wide** decisions: shell layout, bootstrap, m
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [0001](0001-mise-primary-tool-management.md) | mise as primary tool manager | Accepted | 2026-03-23 |
+| [0002](0002-profile-system.md) | Environment-variable-based profile system | Accepted | 2026-04-19 |
+| [0003](0003-symlink-strategy.md) | Symlink strategy for dotfiles deployment | Accepted | 2026-04-19 |
+| [0004](0004-claude-settings-merge.md) | JSONC merge strategy for Claude Code settings | Accepted | 2026-04-19 |
 
 ## Status definitions
 


### PR DESCRIPTION
## Summary

- **ADR 0002 — Profile system**: documents why env-var-based profiles over git branches, hostname detection, or interactive prompts; covers the four-profile model and layered configuration
- **ADR 0003 — Symlink strategy**: documents why symlinks over copy, GNU Stow, bare git repo, or Ansible; covers directory-level linking, the Fish exception, and `make-symlink` semantics
- **ADR 0004 — Claude settings merge**: documents why JSONC + jq merge over single files or templates; covers permission union-merge, internal state preservation, and Node.js/jq dependency

Updates the `docs/architecture/README.md` index with all three new entries.

Closes #58

## Test plan

- [ ] All three ADR files render correctly on GitHub
- [ ] README index links resolve to the correct files
- [ ] ADR format matches existing 0001 style (frontmatter, sections, alternatives table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)