### PR TITLE
fix: update time formatting and enhance status display in wezterm

### DIFF
--- a/home/.config/wezterm/lua/status.lua
+++ b/home/.config/wezterm/lua/status.lua
@@ -35,7 +35,7 @@ local function get_workhours_display(window)
   end
 
   local user_vars = active_pane:get_user_vars() or {}
-  local hours_worked = time_utils.calculate_hour_difference(user_vars.first_login, wezterm.strftime("%H:%M:%S"))
+  local hours_worked = time_utils.calculate_hour_difference(user_vars.first_login, wezterm.strftime("%I:%M:%S"))
   if hours_worked == nil or hours_worked <= 0 or hours_worked >= 10 then
     return wezterm.nerdfonts.fa_hourglass_start, "-.-", color_workhours_start
   end
@@ -61,6 +61,12 @@ local function get_workhours_display(window)
 end
 
 local function update_right_status(window)
+  local leader = ""
+  if window:leader_is_active() then
+    leader = "󰘀"
+  end
+  window:set_left_status(leader)
+
   local waiting_count = 0
   local init_notice = agent_deck.consume_init_notice and agent_deck.consume_init_notice() or nil
   if init_notice then
@@ -81,7 +87,7 @@ local function update_right_status(window)
   end
 
   local date = wezterm.strftime("(%Y-%m-%d) %a %b %-d ")
-  local time = wezterm.strftime("%H:%M")
+  local time = wezterm.strftime("%I:%M")
   local week_number = os.date("%V")
   local workhours_icon, workhours_text, workhours_color = get_workhours_display(window)
 


### PR DESCRIPTION
- Changed time formatting in the status display from 24-hour to 12-hour format for better readability.
- Added a visual indicator for active leader key in the status bar to improve user experience.

These changes enhance the usability of the wezterm status display, making it more user-friendly.

## Related Links

<!-- What links will make reviewing these code changes as straightforward as possible? -->

<!-- - Deploy Preview -->
<!-- - GitHub/Linear/Jira/Asana/etc. Ticket -->
<!-- - User Story -->

## What

<!-- What changes did you make at a high-level? -->

<!-- - Added... -->
<!-- - Updated... -->
<!-- - Refactored... -->
<!-- - Moved... -->

## Why

<!-- Why are these changess helpful or necessary? -->

<!-- - New feature requested... -->
<!-- - Refactoring in preparation for... -->
<!-- - Addressing design feedback... -->
<!-- - Fast-follow to previous PR... -->

## How

<!-- How did you go about making these changes? -->

<!-- - Paired with <Teammate Name> where we did A, B, C -->
<!-- - Tried another approach but it didn't work because X, Y, Z -->
<!-- - I followed this resource by <Author Name>:<Resource Link> -->
<!-- - Used these code APIs/SDKs: <Name>, <Name>, <Name> -->

## Designs

<!-- What visual context do reviewers need? -->

<!-- - Component -->
<!-- - Mockup -->
<!-- - Wireframe -->
<!-- - Prototype -->

## Test Steps

<!-- What are all the steps to testing your code changes? -->

<!-- - [ ] Enable `feature_flag` -->
<!-- - [ ] Go to this page: /a-test-page -->
<!-- - [ ] Simulate "Browser Feature" -->
<!-- - [ ] Scroll to "Example Section Name" -->
<!-- - [ ] It should show... -->
<!-- - [ ] Activate the "Example Button" button -->
<!-- - [ ] You should see... -->
<!-- - [ ] Wait for the page to load... -->
<!-- - [ ] ... -->

## Other Notess

<!-- What, if anything, hasn't been addressed in these code changes but should be in future changes? -->

<!-- - ABC wasn't working as expected... -->
<!-- - XYZ needs more research... -->
<!-- - A fast-follow PR is already planned for addressing 1, 2, 3... -->
